### PR TITLE
feat: reset properties when player goes bankrupt

### DIFF
--- a/project_seperate/src/repository/property_repo.rs
+++ b/project_seperate/src/repository/property_repo.rs
@@ -45,3 +45,12 @@ pub fn get_owned_tiles(conn: &Connection) -> Result<Vec<TileOwnerRecord>> {
 
     Ok(records)
 }
+
+// 소유 토지 초기화
+pub fn reset_owner_for_player(conn: &Connection, player_id: i32) -> rusqlite::Result<()> {
+    conn.execute(
+        "UPDATE properties SET owner_id = NULL WHERE owner_id = ?1",
+        [player_id],
+    )?;
+    Ok(())
+}

--- a/project_seperate/src/service/turn_execute_service.rs
+++ b/project_seperate/src/service/turn_execute_service.rs
@@ -2,7 +2,7 @@ use rusqlite::Connection;
 
 use crate::repository::{
     player_repo::{update_money, update_position_and_lap, bankrupt},
-    property_repo::set_owner,
+    property_repo::{set_owner, reset_owner_for_player},
     transcaction_repo::record_transaction,
 };
 
@@ -101,6 +101,9 @@ pub fn apply_turn_result(
                 *paid,
                 "bankrupt",
             )?;
+
+            // 소유했던 토지 초기화
+            reset_owner_for_player(conn, player_id)?;
 
             bankrupt(conn, player_id)?;
         }


### PR DESCRIPTION
## ☑️ 체크리스트
- [x] 협업 루틴: 이슈 생성 -> 브랜치 생성 -> 개발 -> commit&push -> pull request 작성 -> 팀원 리뷰 -> main 브랜치에 머지 -> 이슈 닫기
*main 브랜치가 아닌 각자 생성한 브랜치에서 작업해야 합니다. PR 및 리뷰 확인 후 main에 머지합니다.
- [x] Assignees & Labels & Development 할당 



## 📌 𝗜𝘀𝘀𝘂𝗲𝘀
closed #17 



## 📦 추가/수정한 파일
- properties_repo.rs: 특정 플레이어에 대해 DB에서 그 플레이어가 소유한 토지를 불러와 초기화하는 함수 추가
- turn_execute_service.rs: 소유 토지를 초기화하는 함수가 실행되도록 로직 추가


## 🎛️ 작업에 대한 설명
- 플레이어가 파산 시, 소유했던 토지를 모두 초기화하는 로직 추가


## 🪜 추후 디벨롭 사항




## 👀 첨부파일

