### PR TITLE
Seperate DB Dependency from Service

### DIFF
--- a/project_seperate/src/service/event_service.rs
+++ b/project_seperate/src/service/event_service.rs
@@ -1,6 +1,5 @@
 use rusqlite::Connection;
 use crate::service::traits::EventServiceRepo;
-use crate::service::port_impl::PortImpl;
 
 
 /// 이벤트 결과
@@ -81,13 +80,4 @@ pub fn handle_event_with_repo<R: EventServiceRepo>(
 
         _ => EventResult::None,
     }
-}
-
-/// 이벤트 처리
-pub fn handle_event(
-    conn: &Connection,
-    player_id: i32,
-    tile_id: i32,
-) -> EventResult {
-    handle_event_with_repo(&PortImpl, conn, player_id, tile_id)
 }

--- a/project_seperate/src/service/event_service.rs
+++ b/project_seperate/src/service/event_service.rs
@@ -1,11 +1,7 @@
 use rusqlite::Connection;
-
-use crate::repository::{
-    event_repo::{get_event_info, get_fund_amount},
-    player_repo::get_player_money,
-    property_repo::get_player_total_property_price,
-};
 use crate::service::traits::EventServiceRepo;
+use crate::service::port_impl::PortImpl;
+
 
 /// 이벤트 결과
 #[derive(Debug, PartialEq)]
@@ -18,26 +14,6 @@ pub enum EventResult {
     FundReceive { amount: i32 },
     FundReceiveEmpty,
     None,
-}
-
-pub struct EventServiceRepository;
-
-impl EventServiceRepo for EventServiceRepository {
-    fn get_event_info(&self, conn: &Connection, tile_id: i32) -> rusqlite::Result<(String, i32)> {
-        get_event_info(conn, tile_id)
-    }
-
-    fn get_player_money(&self, conn: &Connection, player_id: i32) -> rusqlite::Result<i32> {
-        get_player_money(conn, player_id)
-    }
-
-    fn get_player_total_property_price(&self, conn: &Connection, player_id: i32) -> rusqlite::Result<i32> {
-        get_player_total_property_price(conn, player_id)
-    }
-
-    fn get_fund_amount(&self, conn: &Connection) -> rusqlite::Result<i32> {
-        get_fund_amount(conn)
-    }
 }
 
 pub fn handle_event_with_repo<R: EventServiceRepo>(
@@ -113,6 +89,5 @@ pub fn handle_event(
     player_id: i32,
     tile_id: i32,
 ) -> EventResult {
-    let repo = EventServiceRepository;
-    handle_event_with_repo(&repo, conn, player_id, tile_id)
+    handle_event_with_repo(&PortImpl, conn, player_id, tile_id)
 }

--- a/project_seperate/src/service/mod.rs
+++ b/project_seperate/src/service/mod.rs
@@ -8,3 +8,4 @@ pub mod salary_service;
 pub mod traits;
 pub mod turn_service;
 pub mod turn_execute_service;
+pub mod port_impl;

--- a/project_seperate/src/service/orchestrator.rs
+++ b/project_seperate/src/service/orchestrator.rs
@@ -14,8 +14,9 @@ use crate::service::game_end_service::{evaluate_and_apply_game_end, Player as Ga
 use crate::service::turn_execute_service::{apply_turn_result, pre_apply_move_salary, apply_purchase};
 use crate::service::turn_service::{
     build_landing_context, build_turn_result, get_active_game_players,
-    resolve_current_player_id, TurnAction, TurnServiceDepsImpl, roll_and_move_with_deps, TurnResult,
+    resolve_current_player_id, TurnAction, roll_and_move_with_deps, TurnResult,
 };
+use crate::service::port_impl::PortImpl;
 use crate::repository::init::init_db;
 
 // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -208,7 +209,7 @@ pub fn process_turn(
     session: &mut SessionState,
 ) -> rusqlite::Result<TurnOutcome> {
     let repo = TurnRepoImpl;
-    let deps = TurnServiceDepsImpl;
+    let deps = PortImpl;
     process_turn_with_repo(&repo, &deps, conn, session)
 }
 

--- a/project_seperate/src/service/orchestrator.rs
+++ b/project_seperate/src/service/orchestrator.rs
@@ -11,13 +11,14 @@ use crate::service::traits::TurnRepo;
 
 use crate::service::buy_property_service::{is_purchasable_tile, decide_buy_property, BuyResult};
 use crate::service::game_end_service::{evaluate_and_apply_game_end, Player as GamePlayer};
-use crate::service::turn_execute_service::{apply_turn_result, pre_apply_move_salary, apply_purchase};
-use crate::service::turn_service::{
-    build_landing_context, build_turn_result, get_active_game_players,
-    resolve_current_player_id, TurnAction, roll_and_move_with_deps, TurnResult,
-};
-use crate::service::port_impl::PortImpl;
 use crate::repository::init::init_db;
+
+use crate::service::port_impl::PortImpl;
+use crate::service::turn_execute_service::{apply_turn_result_with_repo, pre_apply_move_salary, apply_purchase};
+use crate::service::turn_service::{
+    build_landing_context_with_repo, build_turn_result_with_deps, get_active_game_players_with_repo,
+    resolve_current_player_id_with_repo, TurnAction, roll_and_move_with_deps, TurnResult,
+};
 
 // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 //  세션 및 대기 상태 구조체
@@ -140,7 +141,7 @@ pub struct TurnRepoImpl;
 
 impl TurnRepo for TurnRepoImpl {
     fn get_active_game_players(&self, conn: &Connection) -> rusqlite::Result<Vec<GamePlayer>> {
-        get_active_game_players(conn)
+        get_active_game_players_with_repo(&PortImpl, conn)
     }
     fn get_player_states(&self, conn: &Connection) -> rusqlite::Result<Vec<PlayerState>> {
         get_player_states(conn)
@@ -149,10 +150,10 @@ impl TurnRepo for TurnRepoImpl {
         get_owned_tiles(conn)
     }
     fn resolve_current_player_id(&self, conn: &Connection, idx: usize) -> rusqlite::Result<Option<i32>> {
-        resolve_current_player_id(conn, idx)
+        resolve_current_player_id_with_repo(&PortImpl, conn, idx)
     }
     fn apply_turn_result(&self, conn: &Connection, player_id: i32, result: &TurnResult) -> rusqlite::Result<()> {
-        apply_turn_result(conn, player_id, result)
+        apply_turn_result_with_repo(&PortImpl, conn, player_id, result)
     }
     fn pre_apply_move_salary(&self, conn: &Connection, player_id: i32, pos: i32, lap: i32, salary: i32) -> rusqlite::Result<()> {
         pre_apply_move_salary(conn, player_id, pos, lap, salary)
@@ -186,7 +187,7 @@ pub fn init_session(conn: &Connection) -> rusqlite::Result<SessionState> {
 /// 현재 게임 상태 조회
 pub fn get_state(conn: &Connection, session: &SessionState) -> rusqlite::Result<StateResult> {
     let players = get_player_states(conn)?; // [DB 읽기] repository 직접 호출
-    let current_player_id = resolve_current_player_id(conn, session.current_turn_index)?;
+    let current_player_id = resolve_current_player_id_with_repo(&PortImpl, conn, session.current_turn_index)?;
     let tile_owners = get_owned_tiles(conn)?; // [DB 읽기] repository 직접 호출
 
     Ok(StateResult {
@@ -247,7 +248,8 @@ pub fn process_turn_with_repo<R: TurnRepo, D: TurnServiceDeps>(repo: &R, deps: &
 
     let move_step = roll_and_move_with_deps(deps, current_player.position, current_player.lap, 24);
 
-    let landing = build_landing_context(
+    let landing = build_landing_context_with_repo(
+        &PortImpl,
         conn,
         move_step.new_position,
         current_player.money,
@@ -303,7 +305,8 @@ pub fn process_turn_with_repo<R: TurnRepo, D: TurnServiceDeps>(repo: &R, deps: &
     let old_lap = current_player.lap;
     let player_id = current_player.id;
 
-    let turn_result = build_turn_result(
+    let turn_result = build_turn_result_with_deps(
+        deps,
         conn,
         move_step,
         player_id,
@@ -320,7 +323,7 @@ pub fn process_turn_with_repo<R: TurnRepo, D: TurnServiceDeps>(repo: &R, deps: &
 
     let players_after = get_player_states(conn)?; // [DB 읽기] repository 직접 호출
     let tile_owners = get_owned_tiles(conn)?; // [DB 읽기] repository 직접 호출
-    let current_player_id = resolve_current_player_id(conn, session.current_turn_index)?;
+    let current_player_id = resolve_current_player_id_with_repo(&PortImpl, conn, session.current_turn_index)?;
 
     let (action_type, action_amount, owner_id) = map_action(&turn_result.action);
 
@@ -387,7 +390,7 @@ pub fn process_decide_with_repo<R: TurnRepo>(
 
     let players_after = get_player_states(conn)?; // [DB 읽기] repository 직접 호출
     let tile_owners = get_owned_tiles(conn)?; // [DB 읽기] repository 직접 호출
-    let current_player_id = resolve_current_player_id(conn, session.current_turn_index)?;
+    let current_player_id = resolve_current_player_id_with_repo(&PortImpl, conn, session.current_turn_index)?;
 
     Ok(TurnOutcome {
         player_id: pending.player_id,

--- a/project_seperate/src/service/port_impl.rs
+++ b/project_seperate/src/service/port_impl.rs
@@ -8,7 +8,7 @@ use crate::repository::{
 };
 
 use crate::service::{
-    event_service::{handle_event, EventResult},
+    event_service::{handle_event_with_repo, EventResult},
     roll_dice_service::roll_dice,
     traits::{EventServiceRepo, PlayerStateRepo, TurnExecuteRepo, TurnServiceDeps, TurnServiceQueryRepo},
 };
@@ -53,7 +53,7 @@ impl TurnServiceDeps for PortImpl {
     }
 
     fn handle_event(&self, conn: &Connection, player_id: i32, tile_id: i32) -> EventResult {
-        handle_event(conn, player_id, tile_id)
+        handle_event_with_repo(self, conn, player_id, tile_id)
     }
 }
 

--- a/project_seperate/src/service/port_impl.rs
+++ b/project_seperate/src/service/port_impl.rs
@@ -1,0 +1,80 @@
+use rusqlite::Connection;
+
+use crate::repository::{
+    event_repo::{add_fund, get_event_info, get_fund_amount, reset_fund},
+    player_repo::{bankrupt, get_player_money, get_player_states, update_money, update_position_and_lap, PlayerState},
+    property_repo::{get_player_total_property_price, reset_owner_for_player},
+    transcaction_repo::record_transaction,
+};
+
+use crate::service::{
+    event_service::{handle_event, EventResult},
+    roll_dice_service::roll_dice,
+    traits::{EventServiceRepo, PlayerStateRepo, TurnExecuteRepo, TurnServiceDeps},
+};
+
+pub struct PortImpl;
+
+impl EventServiceRepo for PortImpl {
+    fn get_event_info(&self, conn: &Connection, tile_id: i32) -> rusqlite::Result<(String, i32)> {
+        get_event_info(conn, tile_id)
+    }
+
+    fn get_player_money(&self, conn: &Connection, player_id: i32) -> rusqlite::Result<i32> {
+        get_player_money(conn, player_id)
+    }
+
+    fn get_player_total_property_price(&self, conn: &Connection, player_id: i32) -> rusqlite::Result<i32> {
+        get_player_total_property_price(conn, player_id)
+    }
+
+    fn get_fund_amount(&self, conn: &Connection) -> rusqlite::Result<i32> {
+        get_fund_amount(conn)
+    }
+}
+
+impl TurnServiceDeps for PortImpl {
+    fn roll_dice(&self) -> i32 {
+        roll_dice()
+    }
+
+    fn handle_event(&self, conn: &Connection, player_id: i32, tile_id: i32) -> EventResult {
+        handle_event(conn, player_id, tile_id)
+    }
+}
+
+impl PlayerStateRepo for PortImpl {
+    fn get_player_states(&self, conn: &Connection) -> rusqlite::Result<Vec<PlayerState>> {
+        get_player_states(conn)
+    }
+}
+
+impl TurnExecuteRepo for PortImpl {
+    fn update_position_and_lap(&self, conn: &Connection, player_id: i32, pos: i32, lap: i32) -> rusqlite::Result<()> {
+        update_position_and_lap(conn, player_id, pos, lap)
+    }
+
+    fn update_money(&self, conn: &Connection, player_id: i32, delta: i32) -> rusqlite::Result<()> {
+        update_money(conn, player_id, delta)
+    }
+
+    fn record_transaction(&self, conn: &Connection, player_id: i32, tx_type: &str, amount: i32, target: &str) -> rusqlite::Result<()> {
+        record_transaction(conn, player_id, tx_type, amount, target)
+    }
+
+    fn reset_owner_for_player(&self, conn: &Connection, player_id: i32) -> rusqlite::Result<()> {
+        reset_owner_for_player(conn, player_id)
+    }
+
+    fn bankrupt(&self, conn: &Connection, player_id: i32) -> rusqlite::Result<()> {
+        bankrupt(conn, player_id)
+    }
+
+    fn add_fund(&self, conn: &Connection, amount: i32) -> rusqlite::Result<()> {
+        add_fund(conn, amount)
+    }
+
+    fn reset_fund(&self, conn: &Connection) -> rusqlite::Result<()> {
+        reset_fund(conn)
+    }
+}

--- a/project_seperate/src/service/port_impl.rs
+++ b/project_seperate/src/service/port_impl.rs
@@ -10,7 +10,7 @@ use crate::repository::{
 use crate::service::{
     event_service::{handle_event, EventResult},
     roll_dice_service::roll_dice,
-    traits::{EventServiceRepo, PlayerStateRepo, TurnExecuteRepo, TurnServiceDeps},
+    traits::{EventServiceRepo, PlayerStateRepo, TurnExecuteRepo, TurnServiceDeps, TurnServiceQueryRepo},
 };
 
 pub struct PortImpl;
@@ -30,6 +30,20 @@ impl EventServiceRepo for PortImpl {
 
     fn get_fund_amount(&self, conn: &Connection) -> rusqlite::Result<i32> {
         get_fund_amount(conn)
+    }
+}
+
+impl TurnServiceQueryRepo for PortImpl {
+    fn get_tile_info(&self, conn: &Connection, tile_id: i32) -> rusqlite::Result<(i32, i32, Option<i32>, String)> {
+        crate::repository::tile_repo::get_tile_info(conn, tile_id)
+    }
+
+    fn get_owner(&self, conn: &Connection, tile_id: i32) -> rusqlite::Result<Option<i32>> {
+        crate::repository::property_repo::get_owner(conn, tile_id)
+    }
+
+    fn get_all_players(&self, conn: &Connection) -> rusqlite::Result<Vec<crate::repository::player_repo::PlayerRow>> {
+        crate::repository::player_repo::get_all_players(conn)
     }
 }
 

--- a/project_seperate/src/service/traits.rs
+++ b/project_seperate/src/service/traits.rs
@@ -12,6 +12,12 @@ pub trait EventServiceRepo {
     fn get_fund_amount(&self, conn: &Connection) -> rusqlite::Result<i32>;
 }
 
+pub trait TurnServiceQueryRepo {
+    fn get_tile_info(&self, conn: &Connection, tile_id: i32) -> rusqlite::Result<(i32, i32, Option<i32>, String)>;
+    fn get_owner(&self, conn: &Connection, tile_id: i32) -> rusqlite::Result<Option<i32>>;
+    fn get_all_players(&self, conn: &Connection) -> rusqlite::Result<Vec<crate::repository::player_repo::PlayerRow>>;
+}
+
 pub trait TurnServiceDeps {
     fn roll_dice(&self) -> i32;
     fn handle_event(&self, conn: &Connection, player_id: i32, tile_id: i32) -> EventResult;

--- a/project_seperate/src/service/turn_execute_service.rs
+++ b/project_seperate/src/service/turn_execute_service.rs
@@ -8,7 +8,6 @@ use crate::repository::{
 
 use crate::service::turn_service::{TurnResult, TurnAction};
 use crate::service::traits::TurnExecuteRepo;
-use crate::service::port_impl::PortImpl;
 
 
 // process_turn 함수 실행 결과를 DB에 반영하는 함수 (DI 버전)
@@ -180,14 +179,6 @@ pub fn apply_turn_result_with_repo<R: TurnExecuteRepo>(
     Ok(())
 }
 
-// process_turn 함수 실행 결과를 DB에 반영하는 함수
-pub fn apply_turn_result(
-    conn: &Connection,
-    player_id: i32,
-    result: &TurnResult,
-) -> rusqlite::Result<()> {
-    apply_turn_result_with_repo(&PortImpl, conn, player_id, result)
-}
 
 /// 이동 + 월급만 선반영 (구매 결정 대기 시 사용)
 pub fn pre_apply_move_salary(

--- a/project_seperate/src/service/turn_execute_service.rs
+++ b/project_seperate/src/service/turn_execute_service.rs
@@ -1,41 +1,15 @@
 use rusqlite::Connection;
 
 use crate::repository::{
-    player_repo::{update_money, update_position_and_lap, bankrupt},
-    property_repo::{set_owner, reset_owner_for_player},
+    player_repo::{update_money, update_position_and_lap},
+    property_repo::{set_owner},
     transcaction_repo::record_transaction,
 };
 
 use crate::service::turn_service::{TurnResult, TurnAction};
 use crate::service::traits::TurnExecuteRepo;
+use crate::service::port_impl::PortImpl;
 
-pub struct TurnExecuteRepoImpl;
-
-impl TurnExecuteRepo for TurnExecuteRepoImpl {
-    fn update_position_and_lap(&self, conn: &Connection, player_id: i32, pos: i32, lap: i32) -> rusqlite::Result<()> {
-        update_position_and_lap(conn, player_id, pos, lap)
-    }
-    fn update_money(&self, conn: &Connection, player_id: i32, delta: i32) -> rusqlite::Result<()> {
-        update_money(conn, player_id, delta)
-    }
-    fn record_transaction(&self, conn: &Connection, player_id: i32, tx_type: &str, amount: i32, target: &str) -> rusqlite::Result<()> {
-        record_transaction(conn, player_id, tx_type, amount, target)
-    }
-    fn reset_owner_for_player(&self, conn: &Connection, player_id: i32) -> rusqlite::Result<()> {
-        reset_owner_for_player(conn, player_id)
-    }
-    fn bankrupt(&self, conn: &Connection, player_id: i32) -> rusqlite::Result<()> {
-        bankrupt(conn, player_id)
-    }
-    fn add_fund(&self, conn: &Connection, amount: i32) -> rusqlite::Result<()> {
-        use crate::repository::event_repo::add_fund;
-        add_fund(conn, amount)
-    }
-    fn reset_fund(&self, conn: &Connection) -> rusqlite::Result<()> {
-        use crate::repository::event_repo::reset_fund;
-        reset_fund(conn)
-    }
-}
 
 // process_turn 함수 실행 결과를 DB에 반영하는 함수 (DI 버전)
 pub fn apply_turn_result_with_repo<R: TurnExecuteRepo>(
@@ -212,7 +186,7 @@ pub fn apply_turn_result(
     player_id: i32,
     result: &TurnResult,
 ) -> rusqlite::Result<()> {
-    apply_turn_result_with_repo(&TurnExecuteRepoImpl, conn, player_id, result)
+    apply_turn_result_with_repo(&PortImpl, conn, player_id, result)
 }
 
 /// 이동 + 월급만 선반영 (구매 결정 대기 시 사용)

--- a/project_seperate/src/service/turn_service.rs
+++ b/project_seperate/src/service/turn_service.rs
@@ -10,7 +10,6 @@ use crate::service::{
     game_end_service::Player as GamePlayer,
     traits::TurnServiceDeps,
 };
-use crate::service::port_impl::PortImpl;
 use crate::service::traits::TurnServiceQueryRepo;
 
 
@@ -81,15 +80,6 @@ pub fn build_landing_context_with_repo<R: TurnServiceQueryRepo>(
     }
 }
 
-pub fn build_landing_context(
-    conn: &Connection,
-    new_position: i32,
-    current_money: i32,
-    salary: i32,
-) -> LandingContext {
-    build_landing_context_with_repo(&crate::service::port_impl::PortImpl, conn, new_position, current_money, salary)
-}
-
 
 pub fn build_turn_result_with_deps<D: TurnServiceDeps>(
     deps: &D,
@@ -139,23 +129,6 @@ pub fn build_turn_result_with_deps<D: TurnServiceDeps>(
     }
 }
 
-/// MoveStep → TurnResult 생성 (통행료/이벤트/None 처리, 구매는 process_decide 경로)
-pub fn build_turn_result(
-    conn: &Connection,
-    move_step: MoveStep,
-    player_id: i32,
-    money_after_salary: i32,
-    tile_price: i32,
-    tile_toll: i32,
-    tile_owner: Option<i32>,
-    tile_type: &str,
-) -> TurnResult {
-    build_turn_result_with_deps(
-        &PortImpl, conn, move_step, player_id,
-        money_after_salary, tile_price, tile_toll, tile_owner, tile_type,
-    )
-}
-
 // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 //  플레이어·턴 조회 서비스
 // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -179,10 +152,6 @@ pub fn get_active_game_players_with_repo<R: TurnServiceQueryRepo>(
         .collect())
 }
 
-pub fn get_active_game_players(conn: &Connection) -> rusqlite::Result<Vec<GamePlayer>> {
-    get_active_game_players_with_repo(&crate::service::port_impl::PortImpl, conn)
-}
-
 
 pub fn resolve_current_player_id_with_repo<R: PlayerStateRepo>(
     repo: &R,
@@ -200,14 +169,6 @@ pub fn resolve_current_player_id_with_repo<R: PlayerStateRepo>(
     Ok(Some(active[normalized].id))
 }
 
-/// 현재 턴 인덱스를 기반으로 실제 턴을 진행할 플레이어의 ID를 반환한다.
-///
-/// DB에서 플레이어 상태를 조회한 뒤, 활성(비파산) 플레이어 수로
-/// 인덱스를 정규화하여 해당 플레이어 ID를 계산한다.
-/// 활성 플레이어가 없으면 `None`을 반환한다.
-pub fn resolve_current_player_id(conn: &Connection, current_turn_index: usize) -> rusqlite::Result<Option<i32>> {
-    resolve_current_player_id_with_repo(&PortImpl, conn, current_turn_index)
-}
 
 // 턴 동안 발생한 행동 종류
 #[derive(Debug, Clone, PartialEq)]

--- a/project_seperate/src/service/turn_service.rs
+++ b/project_seperate/src/service/turn_service.rs
@@ -1,20 +1,18 @@
 use rusqlite::Connection;
 
-use crate::repository::player_repo::{
-    get_all_players, PlayerState,
-};
-use crate::repository::{property_repo::get_owner, tile_repo::get_tile_info};
+use crate::repository::player_repo::{PlayerState};
 use crate::service::{
     movement_service::move_player,
     salary_service::calculate_salary,
     buy_property_service::{decide_buy_property, BuyResult},
     traits::PlayerStateRepo,
-    roll_dice_service::roll_dice,
-    event_service::{handle_event, EventResult},
+    event_service::{EventResult},
     game_end_service::Player as GamePlayer,
     traits::TurnServiceDeps,
 };
 use crate::service::port_impl::PortImpl;
+use crate::service::traits::TurnServiceQueryRepo;
+
 
 
 // 한 턴 진행 결과 데이터
@@ -63,15 +61,16 @@ pub fn roll_and_move_with_deps<D: TurnServiceDeps>(
 }
 
 /// 도착 타일 정보와 소유자 조회 + 월급 반영 후 잔액 계산을 한 번에 수행한다.
-pub fn build_landing_context(
+pub fn build_landing_context_with_repo<R: TurnServiceQueryRepo>(
+    repo: &R,
     conn: &Connection,
     new_position: i32,
     current_money: i32,
     salary: i32,
 ) -> LandingContext {
     let (tile_price, tile_toll, _, tile_type) =
-        get_tile_info(conn, new_position).unwrap_or((0, 0, None, String::from("unknown")));
-    let tile_owner = get_owner(conn, new_position).unwrap_or(None);
+        repo.get_tile_info(conn, new_position).unwrap_or((0, 0, None, String::from("unknown")));
+    let tile_owner = repo.get_owner(conn, new_position).unwrap_or(None);
 
     LandingContext {
         tile_price,
@@ -81,6 +80,16 @@ pub fn build_landing_context(
         money_after_salary: current_money + salary,
     }
 }
+
+pub fn build_landing_context(
+    conn: &Connection,
+    new_position: i32,
+    current_money: i32,
+    salary: i32,
+) -> LandingContext {
+    build_landing_context_with_repo(&crate::service::port_impl::PortImpl, conn, new_position, current_money, salary)
+}
+
 
 pub fn build_turn_result_with_deps<D: TurnServiceDeps>(
     deps: &D,
@@ -152,8 +161,11 @@ pub fn build_turn_result(
 // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
 /// DB에서 파산하지 않은 활성 플레이어를 `GamePlayer` 형태로 반환한다.
-pub fn get_active_game_players(conn: &Connection) -> rusqlite::Result<Vec<GamePlayer>> {
-    let rows = get_all_players(conn)?;
+pub fn get_active_game_players_with_repo<R: TurnServiceQueryRepo>(
+    repo: &R,
+    conn: &Connection,
+) -> rusqlite::Result<Vec<GamePlayer>> {
+    let rows = repo.get_all_players(conn)?;
     Ok(rows
         .into_iter()
         .filter(|r| !r.is_bankrupt)
@@ -165,6 +177,10 @@ pub fn get_active_game_players(conn: &Connection) -> rusqlite::Result<Vec<GamePl
             is_bankrupt: r.is_bankrupt,
         })
         .collect())
+}
+
+pub fn get_active_game_players(conn: &Connection) -> rusqlite::Result<Vec<GamePlayer>> {
+    get_active_game_players_with_repo(&crate::service::port_impl::PortImpl, conn)
 }
 
 

--- a/project_seperate/src/service/turn_service.rs
+++ b/project_seperate/src/service/turn_service.rs
@@ -1,7 +1,7 @@
 use rusqlite::Connection;
 
 use crate::repository::player_repo::{
-    get_all_players, get_player_states, PlayerState,
+    get_all_players, PlayerState,
 };
 use crate::repository::{property_repo::get_owner, tile_repo::get_tile_info};
 use crate::service::{
@@ -14,6 +14,8 @@ use crate::service::{
     game_end_service::Player as GamePlayer,
     traits::TurnServiceDeps,
 };
+use crate::service::port_impl::PortImpl;
+
 
 // 한 턴 진행 결과 데이터
 #[derive(Clone, Debug)]
@@ -42,16 +44,6 @@ pub struct LandingContext {
     pub money_after_salary: i32,
 }
 
-pub struct TurnServiceDepsImpl;
-
-impl TurnServiceDeps for TurnServiceDepsImpl {
-    fn roll_dice(&self) -> i32 {
-        roll_dice()
-    }
-    fn handle_event(&self, conn: &Connection, player_id: i32, tile_id: i32) -> EventResult {
-        handle_event(conn, player_id, tile_id)
-    }
-}
 
 pub fn roll_and_move_with_deps<D: TurnServiceDeps>(
     deps: &D,
@@ -150,7 +142,7 @@ pub fn build_turn_result(
     tile_type: &str,
 ) -> TurnResult {
     build_turn_result_with_deps(
-        &TurnServiceDepsImpl, conn, move_step, player_id,
+        &PortImpl, conn, move_step, player_id,
         money_after_salary, tile_price, tile_toll, tile_owner, tile_type,
     )
 }
@@ -175,13 +167,6 @@ pub fn get_active_game_players(conn: &Connection) -> rusqlite::Result<Vec<GamePl
         .collect())
 }
 
-struct PlayerStateRepoImpl;
-
-impl PlayerStateRepo for PlayerStateRepoImpl {
-    fn get_player_states(&self, conn: &Connection) -> rusqlite::Result<Vec<PlayerState>> {
-        get_player_states(conn)
-    }
-}
 
 pub fn resolve_current_player_id_with_repo<R: PlayerStateRepo>(
     repo: &R,
@@ -205,7 +190,7 @@ pub fn resolve_current_player_id_with_repo<R: PlayerStateRepo>(
 /// 인덱스를 정규화하여 해당 플레이어 ID를 계산한다.
 /// 활성 플레이어가 없으면 `None`을 반환한다.
 pub fn resolve_current_player_id(conn: &Connection, current_turn_index: usize) -> rusqlite::Result<Option<i32>> {
-    resolve_current_player_id_with_repo(&PlayerStateRepoImpl, conn, current_turn_index)
+    resolve_current_player_id_with_repo(&PortImpl, conn, current_turn_index)
 }
 
 // 턴 동안 발생한 행동 종류

--- a/project_seperate/src/unit_test/apply_turn_result_fuzz_test.rs
+++ b/project_seperate/src/unit_test/apply_turn_result_fuzz_test.rs
@@ -8,7 +8,8 @@ mod fuzz_apply_turn_result {
     use proptest::prelude::*;
     use rusqlite::Connection;
 
-    use crate::service::turn_execute_service::apply_turn_result;
+    use crate::service::port_impl::PortImpl;
+    use crate::service::turn_execute_service::apply_turn_result_with_repo;
     use crate::service::turn_service::{TurnResult, TurnAction};
 
     // 간단한 DB 초기화
@@ -87,7 +88,7 @@ mod fuzz_apply_turn_result {
                 action,
             };
 
-            let _ = apply_turn_result(&conn, 1, &result);
+            let _ = apply_turn_result_with_repo(&PortImpl, &conn, 1, &result);
 
             // DB 상태 확인
             let (money, is_bankrupt): (i32, i32) =

--- a/project_seperate/src/unit_test/turn_test.rs
+++ b/project_seperate/src/unit_test/turn_test.rs
@@ -1,13 +1,19 @@
 #[cfg(test)]
 mod tests {
     use rusqlite::Connection;
+
     use crate::service::event_service::EventResult;
     use crate::service::turn_service::{
         build_turn_result_with_deps, roll_and_move_with_deps,
         resolve_current_player_id_with_repo,
+        build_landing_context_with_repo, get_active_game_players_with_repo,
         MoveStep, TurnAction,
     };
-    use crate::service::traits::{TurnServiceDeps, PlayerStateRepo};
+    use crate::service::traits::{TurnServiceDeps, PlayerStateRepo, TurnServiceQueryRepo};
+    use crate::service::port_impl::PortImpl;
+
+    use crate::repository::init::init_db;
+    use crate::repository::player_repo::PlayerRow;
     use crate::repository::player_repo::PlayerState;
 
     // ── Mock ──────────────────────────────────────────────
@@ -300,4 +306,57 @@ mod tests {
         assert_eq!(resolve_current_player_id_with_repo(&repo, &dummy_conn(), 0).unwrap(), Some(2));
         assert_eq!(resolve_current_player_id_with_repo(&repo, &dummy_conn(), 1).unwrap(), Some(3));
     }
+
+    // ── build_landing_context_with_repo ──────────────────
+    struct MockTurnServiceQueryRepo {
+        tile_info: (i32, i32, Option<i32>, String),
+        owner: Option<i32>,
+    }
+
+    impl TurnServiceQueryRepo for MockTurnServiceQueryRepo {
+        fn get_tile_info(&self, _conn: &Connection, _tile_id: i32) -> rusqlite::Result<(i32, i32, Option<i32>, String)> {
+            Ok(self.tile_info.clone())
+        }
+
+        fn get_owner(&self, _conn: &Connection, _tile_id: i32) -> rusqlite::Result<Option<i32>> {
+            Ok(self.owner)
+        }
+
+        fn get_all_players(&self, _conn: &Connection) -> rusqlite::Result<Vec<PlayerRow>> {
+            Ok(vec![])
+        }
+    }
+
+    #[test]
+    fn landing_context_with_repo_builds_expected_values() {
+        let repo = MockTurnServiceQueryRepo {
+            tile_info: (120, 15, None, "land".to_string()),
+            owner: Some(2),
+        };
+
+        let ctx = build_landing_context_with_repo(&repo, &dummy_conn(), 7, 80, 20);
+
+        assert_eq!(ctx.tile_price, 120);
+        assert_eq!(ctx.tile_toll, 15);
+        assert_eq!(ctx.tile_owner, Some(2));
+        assert_eq!(ctx.tile_type, "land");
+        assert_eq!(ctx.money_after_salary, 100);
+    }
+
+    // ── get_active_game_players_with_repo ────────────────
+    #[test]
+    fn get_active_game_players_with_repo_filters_bankrupt_players() {
+        let conn = dummy_conn();
+        init_db::init_db(&conn).unwrap();
+
+        // 한 명을 파산 처리해서 필터링 동작 확인
+        conn.execute("UPDATE players SET is_bankrupt = 1 WHERE id = 1", []).unwrap();
+
+        let players = get_active_game_players_with_repo(&PortImpl, &conn).unwrap();
+
+        assert!(!players.is_empty());
+        assert!(players.iter().all(|p| !p.is_bankrupt));
+        assert!(players.iter().all(|p| p.id != 1));
+    }
+
 }

--- a/project_seperate/src/unit_test/turn_test.rs
+++ b/project_seperate/src/unit_test/turn_test.rs
@@ -359,4 +359,37 @@ mod tests {
         assert!(players.iter().all(|p| p.id != 1));
     }
 
+    // ── is_bankrupt ─────────────────
+    // is_bankrupt() == true 검증
+    #[test]
+    fn test_is_bankrupt_true_cases() {
+        let cases = vec![
+            TurnAction::Bankrupt { owner_id: 1, paid: 100 },
+            TurnAction::EventWelfareFundBankrupt { paid: 50 },
+            TurnAction::EstateTaxBankrupt { paid: 30 },
+        ];
+
+        for action in cases {
+            assert!(action.is_bankrupt());
+        }
+    }
+
+    // is_bankrupt() == false 검증
+    #[test]
+    fn test_is_bankrupt_false_cases() {
+        let cases = vec![
+            TurnAction::None,
+            TurnAction::PayToll { owner_id: 1, amount: 100 },
+            TurnAction::EventWelfareFund { amount: 200 },
+            TurnAction::EventFundReceive { amount: 300 },
+            TurnAction::FundReceiveEmpty,
+            TurnAction::EstateTax { amount: 400 },
+            TurnAction::EstateTaxSkipped,
+        ];
+
+        for action in cases {
+            assert!(!action.is_bankrupt());
+        }
+    }
+
 }

--- a/project_seperate/tests/case_test.rs
+++ b/project_seperate/tests/case_test.rs
@@ -24,14 +24,24 @@ mod integration_case_tests {
     }
     struct MockDeps {
         dice: i32,
+        event_result: EventResult,
     }
 
     impl TurnServiceDeps for MockDeps {
         fn roll_dice(&self) -> i32 {
             self.dice
         }
-        fn handle_event(&self, _conn: &Connection, _player_id: i32, _tile_id: i32,) -> EventResult {
-            EventResult::None
+        fn handle_event(&self, _conn: &Connection, _player_id: i32, _tile_id: i32) -> EventResult {
+            match &self.event_result {
+                EventResult::WelfareFund { amount } => EventResult::WelfareFund { amount: *amount },
+                EventResult::WelfareFundBankrupt { paid } => EventResult::WelfareFundBankrupt { paid: *paid },
+                EventResult::EstateTax { amount } => EventResult::EstateTax { amount: *amount },
+                EventResult::EstateTaxBankrupt { paid } => EventResult::EstateTaxBankrupt { paid: *paid },
+                EventResult::EstateTaxSkipped => EventResult::EstateTaxSkipped,
+                EventResult::FundReceive { amount } => EventResult::FundReceive { amount: *amount },
+                EventResult::FundReceiveEmpty => EventResult::FundReceiveEmpty,
+                EventResult::None => EventResult::None,
+            }
         }
     }
 
@@ -78,7 +88,10 @@ mod integration_case_tests {
 
         let result = process_turn_with_repo(
             &repo,
-            &MockDeps { dice: 3 },
+            &MockDeps { 
+                dice: 3,
+                event_result: EventResult::None,
+            },
             &conn,
             &mut session,
         ).unwrap();
@@ -130,7 +143,10 @@ mod integration_case_tests {
 
         let result = process_turn_with_repo(
             &repo,
-            &MockDeps { dice: 3 },
+            &MockDeps { 
+                dice: 3,
+                event_result: EventResult::None,
+            },
             &conn,
             &mut session,
         ).unwrap();
@@ -182,7 +198,10 @@ mod integration_case_tests {
 
         let result = process_turn_with_repo(
             &repo,
-            &MockDeps { dice: 3 },
+            &MockDeps { 
+                dice: 3,
+                event_result: EventResult::None,
+            },
             &conn,
             &mut session,
         ).unwrap();
@@ -241,7 +260,10 @@ mod integration_case_tests {
         let repo = TurnRepoImpl;
         let result = process_turn_with_repo(
             &repo,
-            &MockDeps { dice: 3 },
+            &MockDeps { 
+                dice: 3,
+                event_result: EventResult::None,
+            },
             &conn,
             &mut session,
         ).unwrap();
@@ -284,7 +306,10 @@ mod integration_case_tests {
         let repo = TurnRepoImpl;
         let result = process_turn_with_repo(
             &repo,
-            &MockDeps { dice: 5 },
+            &MockDeps { 
+                dice: 5,
+                event_result: EventResult::None,
+            },
             &conn,
             &mut session,
         ).unwrap();
@@ -330,7 +355,10 @@ mod integration_case_tests {
         let repo = TurnRepoImpl;
         let result = process_turn_with_repo(
             &repo,
-            &MockDeps { dice: 3 },
+            &MockDeps { 
+                dice: 3,
+                event_result: EventResult::None,
+            },
             &conn,
             &mut session,
         ).unwrap();
@@ -374,7 +402,10 @@ mod integration_case_tests {
         let repo = TurnRepoImpl;
         let result = process_turn_with_repo(
             &repo,
-            &MockDeps { dice: 3 },
+            &MockDeps { 
+                dice: 3,
+                event_result: EventResult::None,
+            },
             &conn,
             &mut session,
         ).unwrap();
@@ -423,7 +454,10 @@ mod integration_case_tests {
         let repo = TurnRepoImpl;
         let result = process_turn_with_repo(
             &repo,
-            &MockDeps { dice: 4 },
+            &MockDeps { 
+                dice: 4,
+                event_result: EventResult::WelfareFund { amount: 10 },
+            },
             &conn,
             &mut session,
         ).unwrap();
@@ -464,7 +498,10 @@ mod integration_case_tests {
         let repo = TurnRepoImpl;
         let result = process_turn_with_repo(
             &repo,
-            &MockDeps { dice: 4 },
+            &MockDeps { 
+                dice: 4,
+                event_result: EventResult::WelfareFundBankrupt { paid: 3 },
+            },
             &conn,
             &mut session,
         ).unwrap();
@@ -507,7 +544,10 @@ mod integration_case_tests {
         let repo = TurnRepoImpl;
         let result = process_turn_with_repo(
             &repo,
-            &MockDeps { dice: 4 },
+            &MockDeps { 
+                dice: 4,
+                event_result: EventResult::FundReceive { amount: 30 },
+            },
             &conn,
             &mut session,
         ).unwrap();
@@ -548,7 +588,10 @@ mod integration_case_tests {
         let repo = TurnRepoImpl;
         let result = process_turn_with_repo(
             &repo,
-            &MockDeps { dice: 4 },
+            &MockDeps { 
+                dice: 4,
+                event_result: EventResult::FundReceiveEmpty,
+            },
             &conn,
             &mut session,
         ).unwrap();
@@ -594,7 +637,10 @@ mod integration_case_tests {
         let repo = TurnRepoImpl;
         let result = process_turn_with_repo(
             &repo,
-            &MockDeps { dice: 4 },
+            &MockDeps { 
+                dice: 4,
+                event_result: EventResult::EstateTax { amount: 30 },
+            },
             &conn,
             &mut session,
         ).unwrap();
@@ -633,7 +679,10 @@ mod integration_case_tests {
         let repo = TurnRepoImpl;
         let result = process_turn_with_repo(
             &repo,
-            &MockDeps { dice: 4 },
+            &MockDeps { 
+                dice: 4,
+                event_result: EventResult::EstateTaxBankrupt { paid: 10 },
+            },
             &conn,
             &mut session,
         ).unwrap();
@@ -675,7 +724,10 @@ mod integration_case_tests {
         let repo = TurnRepoImpl;
         let result = process_turn_with_repo(
             &repo,
-            &MockDeps { dice: 4 },
+            &MockDeps { 
+                dice: 4,
+                event_result: EventResult::EstateTaxSkipped,
+            },
             &conn,
             &mut session,
         ).unwrap();
@@ -721,7 +773,10 @@ mod integration_case_tests {
         let repo = TurnRepoImpl;
         let result = process_turn_with_repo(
             &repo,
-            &MockDeps { dice: 3 },
+            &MockDeps { 
+                dice: 3,
+                event_result: EventResult::None,
+            },
             &conn,
             &mut session,
         ).unwrap();


### PR DESCRIPTION
## ☑️ 체크리스트
- [x] 협업 루틴: 이슈 생성 -> 브랜치 생성 -> 개발 -> commit&push -> pull request 작성 -> 팀원 리뷰 -> main 브랜치에 머지 -> 이슈 닫기
*main 브랜치가 아닌 각자 생성한 브랜치에서 작업해야 합니다. PR 및 리뷰 확인 후 main에 머지합니다.
- [x] Assignees & Labels & Development 할당 


## 📌 𝗜𝘀𝘀𝘂𝗲𝘀
closed #65 



## 🎛️ 작업에 대한 설명  
기존 단위검증에서 커버되지 않던 DB 함수들을 서비스 스크립트에서 분리하여 테스트 대상에서 제외시킴
DB 함수의 종류는 다음 3가지로 분류됨  
- impl 내부 구현체 함수
- 실질 로직의 wrapper 함수 (`_with_repo`가 붙어있지 않은 함수, 예: `handle_event`)
- 그 외 DB write 함수: `turn_execute_service.rs`의 `pre_apply_move_salary`, `apply_purchase`

각각 다음과 같은 방법으로 분리함
- `service/port_impl.rs`을 추가하여 서비스 스크립트에 흩어져있던 구현체 함수들을 통합/정리함
- `orchestrator.rs`에서 바로 `_with_repo` 함수들을 호출하게 함으로써 wrapper 함수들을 제거함
- 저수준 DB write 조합이라 통합검증(인메모리 DB)로 충분히 신뢰를 확보할 수 있음. 굳이 DI 구조로 리팩토링해서 얻는 실익이 없음. 오버엔지니어링 -> **추후 논의 및 디벨롭 필요**

`turn_service.rs`의 `get_active_game_players`와 `build_landing_context`는 위의 3가지 종류 중 어느 곳에도 속하지 않았으나, DI 버전으로 리팩토링하며 실질 로직 함수(`*_with_repo`)는 Mock 데이터를 활용한 단위검증으로 커버하고 wrapper 함수는 2번째 종류의 함수들과 마찬가지로 제거함

64번 PR의 디벨롭 사항에서 언급되었던 'DB 로직과 서비스 로직을 분리'하는 방향으로 리팩토링을 진행하였으나, 이 과정에서 DI 버전으로의 교체가 불가피하여 이를 병행함



## 커밋 로그
1. remove impl from service logic: impl 내부 구현체 함수들을 `port_impl.rs`로 통합/정리
2. unify all service fn into DI: `get_active_game_players`와 `build_landing_context`의 DI 버전 추가
3. remove wrappwe from service: `orchestrator.rs`의 호출부 수정 및 wrapper 함수 제거
4. add test fn: `get_active_game_players`와 `build_landing_context`에 대한 단위검증 테스트 함수 추가
5. solve test fail: 하기에서 부연설명


 ## 통합테스트 에러 해결
- 리팩토링 과정에서 wrapper가 사라지면서 `deps.handle_event`의 결과(EventResult::None)에 대한 중간 보정이 없어짐. 최종 `action_type`도 그대로 none이 되는 문제 발생.
- 테스트 케이스 함수에 직접 EventResult를 입력값으로 넣어줌 
- 테스트 계층을 분리하여 `case_test.rs`에서는 이벤트 판정 자체를 검증하지 않고, 주어진 EventResult가 들어왔을 때 전체 턴 흐름과 DB 반영이 올바른지 검증
 
`event_test`: 이벤트 판정 로직 검증, 이 이벤트 조건이면 어떤 EventResult가 나와야 하는가
-> `turn_test`: 매핑 검증, 이 EventResult 값을 받았을 때 어떤 TurnAction이 나와야 하는가
-> `case_test`: 주어진 EventResult가 들어왔을 때 실제 턴 진행이 되는가
 

## 🪜 추후 디벨롭 사항
- `game_end_service.rs` 커버리지 확보
- `turn_execute_service.rs`의 `pre_apply_move_salary`, `apply_purchase` 커버 방향 고안
- `case_test.rs`가 주입된 EventResult를 어떻게 소비하는지 검증하는 걸로 바뀌면서, 이미 판정된 결과(EventResult)가 입력되기 때문에, 실질적인 서비스 분기를 타지 않는 문제 발생 -> 통합검증 분기 커버리지 손실 


## 👀 첨부파일
- 단위검증만: cargo llvm-cov --html --open --branch --lib --ignore-filename-regex "src[\\/](repository|unit_test)[\\/]|handler\.rs|orchestrator\.rs|port_impl\.rs"
<img width="825" height="303" alt="image" src="https://github.com/user-attachments/assets/3ac05870-86c7-4f8d-aedd-2e3aa0e592c6" />

- 통합검증만: cargo llvm-cov --html --open --branch --test integration_test --test case_test --ignore-filename-regex "src[\\/](repository|unit_test)[\\/]"  
<img width="797" height="367" alt="image" src="https://github.com/user-attachments/assets/0c8a67ad-49d6-465e-81cc-30a58f5d6249" />
 
- 단위+통합: cargo llvm-cov --html --open --branch --lib --test integration_test --test case_test --ignore-filename-regex "src[\\/](repository|unit_test)[\\/]"
<img width="796" height="367" alt="image" src="https://github.com/user-attachments/assets/7f87c1d0-1679-4988-a9ab-c6e337735b74" />

